### PR TITLE
Add Bitter font for serif typography

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -37,6 +37,12 @@ export default defineConfig({
         cssVariable: "--font-jetbrains-mono",
         weights: ["400 800"],
       },
+      {
+        provider: fontProviders.google(),
+        name: "Bitter",
+        cssVariable: "--font-bitter",
+        weights: ["400", "600"],
+      },
     ],
   },
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -41,7 +41,7 @@ export default defineConfig({
         provider: fontProviders.google(),
         name: "Bitter",
         cssVariable: "--font-bitter",
-        weights: ["400", "600"],
+        weights: ["400 800"],
       },
     ],
   },

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5,6 +5,9 @@
   --font-mono:
     var(--font-jetbrains-mono), ui-monospace, SFMono-Regular, Menlo, Monaco,
     Consolas, "Liberation Mono", "Courier New", monospace;
+  --font-serif:
+    var(--font-bitter), ui-serif, Georgia, Cambria, "Times New Roman", Times,
+    serif;
 }
 
 @theme {


### PR DESCRIPTION
- Configure Bitter font in Astro with weights 400 and 600
- Update font-serif stack to use Bitter as primary serif font
- Maintain fallback to standard serif fonts